### PR TITLE
Deal with large clusters with small numbers of connected nodes

### DIFF
--- a/src/main/scala/software/uncharted/graphing/layout/forcedirected/ForceDirectedLayout.scala
+++ b/src/main/scala/software/uncharted/graphing/layout/forcedirected/ForceDirectedLayout.scala
@@ -204,9 +204,21 @@ class ForceDirectedLayout (parameters: ForceDirectedLayoutParameters) extends Se
     val isolatedLayout = layoutIsolatedNodes(isolatedNodes, bounds, collectedRadius)
     isolatedNodeCallback.foreach(_(isolatedLayout))
 
-    val connectedLayout = layoutConnectedNodes(connectedNodes.toSeq, edges, parentId,
-      new Circle(bounds.center, collectedRadius),
-      connectedInternalNodes)
+    val connectedNodeSeq = connectedNodes.toSeq
+    val connectedNodeBounds = new Circle(bounds.center, collectedRadius)
+    val connectedLayout =
+      connectedNodeSeq.length match {
+        case 0 =>
+          Iterable[LayoutNode]()
+        case 1 =>
+          oneNodeLayout(connectedNodeSeq, parentId, connectedNodeBounds)
+        case 2 | 3 | 4 =>
+          smallNodeLayout(connectedNodeSeq, parentId, connectedNodeBounds)
+        case _ =>
+          layoutConnectedNodes(connectedNodes.toSeq, edges, parentId,
+            connectedNodeBounds,
+            connectedInternalNodes)
+      }
 
     isolatedLayout ++ connectedLayout
   }


### PR DESCRIPTION
Scaling fails with tiny clusters - it can get in situations where the scaling denominator is zero, because the farthest-out node is centered.  We already test above if there are very few nodes overall, and lay out differently in those cases - the smart thing to do is to do the same thing when we encounter only small numbers of connected nodes in a cluster that is otherwise large enought (i.e., has large numbers of disconnected nodes)